### PR TITLE
Fixed the dependency/setup issue

### DIFF
--- a/.github/workflows/qiita-plugin-ci.yml
+++ b/.github/workflows/qiita-plugin-ci.yml
@@ -59,7 +59,7 @@ jobs:
 
           # Setting up main qiita conda environment
           conda config --add channels conda-forge
-          conda create -q --yes -n qiita python=3.9 pip libgfortran numpy nginx cython redis
+          conda create -q --yes -n qiita python=3.9 pip libgfortran numpy nginx cython redis pysam
           conda activate qiita
           pip install sphinx sphinx-bootstrap-theme nose-timer codecov Click
 

--- a/.github/workflows/qiita-plugin-ci.yml
+++ b/.github/workflows/qiita-plugin-ci.yml
@@ -61,7 +61,7 @@ jobs:
           conda config --add channels conda-forge
           conda create -q --yes -n qiita python=3.9 pip libgfortran numpy nginx cython redis
           conda activate qiita
-          pip install sphinx sphinx-bootstrap-theme nose-timer codecov Click pysam
+          pip install sphinx sphinx-bootstrap-theme nose-timer codecov Click
 
       - name: Qiita install
         shell: bash -l {0}

--- a/.github/workflows/qiita-plugin-ci.yml
+++ b/.github/workflows/qiita-plugin-ci.yml
@@ -59,9 +59,9 @@ jobs:
 
           # Setting up main qiita conda environment
           conda config --add channels conda-forge
-          conda create -q --yes -n qiita python=3.9 pip libgfortran numpy nginx cython redis pysam
+          conda create -q --yes -n qiita python=3.9 pip libgfortran numpy nginx cython redis
           conda activate qiita
-          pip install sphinx sphinx-bootstrap-theme nose-timer codecov Click
+          pip install sphinx sphinx-bootstrap-theme nose-timer codecov Click pysam
 
       - name: Qiita install
         shell: bash -l {0}

--- a/.github/workflows/qiita-plugin-ci.yml
+++ b/.github/workflows/qiita-plugin-ci.yml
@@ -74,7 +74,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda config --add channels bioconda
-          conda create -q --yes -n qtp-bam python=3.9 pip pigz quast fqtools
+          conda create -q --yes -n qtp-bam python=3.9 pip pigz quast fqtools pysam pysamstats
           conda activate qtp-bam
 
           export QIITA_SERVER_CERT=`pwd`/qiita-dev/qiita_core/support_files/server.crt

--- a/qtp_bam/__init__.py
+++ b/qtp_bam/__init__.py
@@ -25,11 +25,15 @@ from .summary import generate_html_summary
 # is a boolean indicating if the filepath type is required to successfully
 # create an artifact of the given type
 
+# NOTE FROM NIEMA: The example above seems to be out of date:
+#                  it doesn't match the current BIOM example https://github.com/qiita-spots/qtp-biom/blob/731b5529fc5f559a868c1d3a6e14cecf4e59198b/qtp_biom/__init__.py#L16-L19
+#                  because it's missing the IS_USER_UPLOADABLE boolean https://github.com/qiita-spots/qiita_client/blob/0e04e78578c8924f65e12ef6813ebadd2886c5e9/qiita_client/plugin.py#L126-L128
+
 # Initialize the plugin
 
 # NOTE: may have to revisit LIST_OF_ACCEPTED_FILEPATH_TYPE
 artifact_types = [
-    QiitaArtifactType('BAM', 'BAM file', False, False, [('bam', True), ('directory', False)])
+    QiitaArtifactType('BAM', 'BAM file', False, False, True, [('bam', True), ('directory', False)])
 
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,6 @@ setup(name='BAM Qiita Type Plugin',
       package_data={'qtp_bam': ['support_files/config_file.cfg']},
       scripts=glob('scripts/*'),
       extras_require={'test': ["nose >= 0.10.1", "pep8"]},
-      install_requires=['click >= 3.3', 'qiita_client @ git+ssh://git@github.com/qiita-spots/qiita_client.git'],
+      install_requires=['click >= 3.3', 'qiita_client @ git+https://github.com/qiita-spots/qiita_client.git'],
       classifiers=classifiers
       )

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(name='BAM Qiita Type Plugin',
       package_data={'qtp_bam': ['support_files/config_file.cfg']},
       scripts=glob('scripts/*'),
       extras_require={'test': ["nose >= 0.10.1", "pep8"]},
-      install_requires=['click >= 3.3', 'Cython', 'pysam', 'pysamstats', 'qiita_client @ git+https://github.com/qiita-spots/qiita_client.git'],
+      setup_requires=['Cython'],
+      install_requires=['click >= 3.3', 'pysam', 'pysamstats', 'qiita_client @ git+https://github.com/qiita-spots/qiita_client.git'],
       classifiers=classifiers
       )

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,6 @@ setup(name='BAM Qiita Type Plugin',
       package_data={'qtp_bam': ['support_files/config_file.cfg']},
       scripts=glob('scripts/*'),
       extras_require={'test': ["nose >= 0.10.1", "pep8"]},
-      install_requires=['click >= 3.3', 'qiita_client'],
+      install_requires=['click >= 3.3', 'qiita_client @ git+ssh://git@github.com/qiita-spots/qiita_client.git'],
       classifiers=classifiers
       )

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ setup(name='BAM Qiita Type Plugin',
       package_data={'qtp_bam': ['support_files/config_file.cfg']},
       scripts=glob('scripts/*'),
       extras_require={'test': ["nose >= 0.10.1", "pep8"]},
-      setup_requires=['Cython'],
-      install_requires=['click >= 3.3', 'pysam', 'pysamstats', 'qiita_client @ git+https://github.com/qiita-spots/qiita_client.git'],
+      install_requires=['click >= 3.3', 'qiita_client @ git+https://github.com/qiita-spots/qiita_client.git'],
       classifiers=classifiers
       )

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,6 @@ setup(name='BAM Qiita Type Plugin',
       package_data={'qtp_bam': ['support_files/config_file.cfg']},
       scripts=glob('scripts/*'),
       extras_require={'test': ["nose >= 0.10.1", "pep8"]},
-      install_requires=['click >= 3.3', 'qiita_client @ git+https://github.com/qiita-spots/qiita_client.git'],
+      install_requires=['click >= 3.3', 'pysam', 'qiita_client @ git+https://github.com/qiita-spots/qiita_client.git'],
       classifiers=classifiers
       )

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,6 @@ setup(name='BAM Qiita Type Plugin',
       package_data={'qtp_bam': ['support_files/config_file.cfg']},
       scripts=glob('scripts/*'),
       extras_require={'test': ["nose >= 0.10.1", "pep8"]},
-      install_requires=['click >= 3.3', 'pysam', 'qiita_client @ git+https://github.com/qiita-spots/qiita_client.git'],
+      install_requires=['click >= 3.3', 'pysam', 'pysamstats', 'qiita_client @ git+https://github.com/qiita-spots/qiita_client.git'],
       classifiers=classifiers
       )

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,6 @@ setup(name='BAM Qiita Type Plugin',
       package_data={'qtp_bam': ['support_files/config_file.cfg']},
       scripts=glob('scripts/*'),
       extras_require={'test': ["nose >= 0.10.1", "pep8"]},
-      install_requires=['click >= 3.3', 'pysam', 'pysamstats', 'qiita_client @ git+https://github.com/qiita-spots/qiita_client.git'],
+      install_requires=['click >= 3.3', 'Cython', 'pysam', 'pysamstats', 'qiita_client @ git+https://github.com/qiita-spots/qiita_client.git'],
       classifiers=classifiers
       )


### PR DESCRIPTION
There are still tests failing, so you'll need to fix those, but this at least gets us over the immediate hurdle. Summary of edits:
* Added `pysam` and `pysamstats` packages to the `conda create` command for creating the `qtp-bam` environment
* The `QiitaArtifactType` object creation was missing a positional argument (`IS_USER_UPLOADABLE`), which was missing from the example in the comments at the top of the `__init__.py` file for some reason (but it exists in the actual BIOM example plugin)
* Updated the `install_requires` entry for `qiita_client` to provide the full `git` path instead of just the package name (because `qiita_client` is not on PyPI, so `pip` needs the `git` info)